### PR TITLE
Parameterized queries

### DIFF
--- a/R/endpoint.R
+++ b/R/endpoint.R
@@ -96,7 +96,6 @@ kusto_query_endpoint <- function(..., .connection_string=NULL, .azure_token=NULL
     props$use_integer64 <- .use_integer64
 
     props <- handle_unsupported(props)
-
     class(props) <- "kusto_database_endpoint"
     props
 }
@@ -222,14 +221,15 @@ handle_unsupported <- function(props)
     if(identical(props$response_dynamic_serialization, "json"))
     {
         warning("Serialization of dynamic response to JSON is not yet supported")
-        props$response_dynamic_serialization <- NULL
     }
 
     if(identical(props$response_dynamic_serialization_2, "json"))
     {
         warning("Serialization of dynamic response to JSON is not yet supported")
-        props$response_dynamic_serialization_2 <- NULL
     }
+
+    props$response_dynamic_serialization <- "string"
+    props$response_dynamic_serialization_2 <- "string"
 
     props
 }

--- a/R/endpoint.R
+++ b/R/endpoint.R
@@ -218,18 +218,19 @@ handle_unsupported <- function(props)
         props$use_integer64 <- FALSE
     }
 
-    if(identical(props$response_dynamic_serialization, "json"))
+    if(!is_empty(props$response_dynamic_serialization) &&
+       tolower(props$response_dynamic_serialization) != "string")
     {
         warning("Serialization of dynamic response to JSON is not yet supported")
+        props$response_dynamic_serialization <- NULL
     }
 
-    if(identical(props$response_dynamic_serialization_2, "json"))
+    if(!is_empty(props$response_dynamic_serialization_2) &&
+       tolower(props$response_dynamic_serialization_2) != "string")
     {
         warning("Serialization of dynamic response to JSON is not yet supported")
+        props$response_dynamic_serialization_2 <- NULL
     }
-
-    props$response_dynamic_serialization <- "string"
-    props$response_dynamic_serialization_2 <- "string"
 
     props
 }

--- a/R/query.R
+++ b/R/query.R
@@ -26,8 +26,9 @@ run_query <- function(database, ...)
 
 #' @rdname query
 #' @export
-run_query.kusto_database_endpoint <- function(database, query, query_params=list(), ...)
+run_query.kusto_database_endpoint <- function(database, query, ...)
 {
+    query_params <- list(...)
     server <- database$server
     db <- database$database
     token <- database$token

--- a/README.md
+++ b/README.md
@@ -44,13 +44,11 @@ head(res)
 
 ```
 
-`run_query()` also supports query parameters. Simply pass a list containing your parameters and they will be interpolated into the query string with proper escaping.
+`run_query()` also supports query parameters. Simply pass your parameters as additional keyword arguments and they will be escaped and interpolated into the query string.
 
 ```r
 
-params <- list(lim=10L)
-
-res <- run_query(Samples, "MyFunction(lim)", query_params=params)
+res <- run_query(Samples, "MyFunction(lim)", lim=10L)
 
 ```
 
@@ -100,6 +98,29 @@ collect(q)
 ##  9 COLORADO             1654
 ## 10 CONNECTICUT           148
 ## # ... with 57 more rows
+
+```
+
+`tbl_kusto` also accepts query parameters, in case the Kusto source table is a parameterized function:
+
+```r
+
+MyFunctionDate <- tbl_kusto(Samples, "MyFunctionDate(dt)", dt=as.Date("2019-01-01"))
+
+MyFunctionDate %>%
+    select(StartTime, EndTime, EpisodeId, EventId, State) %>%
+    head() %>%
+    collect()
+
+## # A tibble: 6 x 5
+##   StartTime           EndTime             EpisodeId EventId State         
+##   <dttm>              <dttm>                  <int>   <int> <chr>         
+## 1 2007-09-29 08:11:00 2007-09-29 08:11:00     11091   61032 ATLANTIC SOUTH
+## 2 2007-09-18 20:00:00 2007-09-19 18:00:00     11074   60904 FLORIDA       
+## 3 2007-09-20 21:57:00 2007-09-20 22:05:00     11078   60913 FLORIDA       
+## 4 2007-12-30 16:00:00 2007-12-30 16:05:00     11749   64588 GEORGIA       
+## 5 2007-12-20 07:50:00 2007-12-20 07:53:00     12554   68796 MISSISSIPPI   
+## 6 2007-12-20 10:32:00 2007-12-20 10:36:00     12554   68814 MISSISSIPPI   
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -32,22 +32,34 @@ Now you can issue queries to the Kusto database with `run_query` and get the res
 
 res <- run_query(Samples, "StormEvents | summarize EventCount = count() by State | order by State asc")
 
-as_tibble(res)
+head(res)
 
-## # A tibble: 67 x 2
-##    State          EventCount
-##    <chr>               <dbl>
-##  1 ALABAMA              1315
-##  2 ALASKA                257
-##  3 AMERICAN SAMOA         16
-##  4 ARIZONA               340
-##  5 ARKANSAS             1028
-##  6 ATLANTIC NORTH        188
-##  7 ATLANTIC SOUTH        193
-##  8 CALIFORNIA            898
-##  9 COLORADO             1654
-## 10 CONNECTICUT           148
-## # ... with 57 more rows
+##            State EventCount
+## 1        ALABAMA       1315
+## 2         ALASKA        257
+## 3 AMERICAN SAMOA         16
+## 4        ARIZONA        340
+## 5       ARKANSAS       1028
+## 6 ATLANTIC NORTH        188
+
+```
+
+`run_query()` also supports query parameters. Simply pass a list containing your parameters and they will be interpolated into the query string with proper escaping.
+
+```r
+
+params <- list(lim=10L)
+
+res <- run_query(Samples, "MyFunction(lim)", query_params=params)
+
+```
+
+Command statements can be run with `run_command()`.
+Note that commands do not accept parameters.
+
+```r
+
+res <- run_command(Samples, ".show tables | count")
 
 ```
 

--- a/man/query.Rd
+++ b/man/query.Rd
@@ -18,7 +18,7 @@ run_command(database, ...)
 \arguments{
 \item{database}{A Kusto database endpoint object, as returned by \code{kusto_query_endpoint}.}
 
-\item{...}{Other arguments passed to lower-level functions, and ultimately to \code{httr::POST}.}
+\item{...}{For \code{run_query}, named arguments to be used as parameters for a parameterized query.}
 
 \item{query, command}{A string containing the query or command. Note that database management commands in KQL are distinct from queries.}
 }

--- a/man/tbl_kusto.Rd
+++ b/man/tbl_kusto.Rd
@@ -11,7 +11,7 @@ tbl_kusto(kusto_database, table_name, ...)
 
 \item{table_name}{The name of the table in the Kusto database}
 
-\item{...}{needed for agreement with generic. Not otherwise used.}
+\item{...}{parameters to pass in case the Kusto source table is a parameterized function.}
 }
 \description{
 A tbl object representing a table in a Kusto database.

--- a/tests/testthat/test03_resource.R
+++ b/tests/testthat/test03_resource.R
@@ -14,7 +14,7 @@ if(username == "")
 
 srvloc <- Sys.getenv("AZ_TEST_KUSTO_NEW_LOCATION")
 if(srvloc == "")
-    stop("Resource creation tests skipped: no location set")
+    skip("Resource creation tests skipped: no location set")
 
 
 sub <- AzureRMR::az_rm$new(tenant=tenant, app=app, password=password)$get_subscription(subscription)

--- a/tests/testthat/test_query_params.R
+++ b/tests/testthat/test_query_params.R
@@ -13,3 +13,27 @@ test_that("Query parameter types can be assigned appropriately",
         types,
         "declare query_parameters (foo:string, bar:int, baz:bool, quux:real, dt:datetime); ")
 })
+
+test_that("build_request_body without params gives expected result",
+{
+    body <- build_request_body("Samples", "StormEvents | take 5")
+    expect_null(body$properties$Parameters)
+    expect_equal(body$db, "Samples")
+    expect_equal(body$csl, "StormEvents | take 5")
+})
+
+test_that("build_request_body without params gives expected result",
+{
+    params <- list(
+        foo="hi",
+        bar=1L,
+        baz=FALSE,
+        quux=1.1
+    )
+    body <- build_request_body("Samples",
+                               "MyFunction(foo, bar, baz, quux)",
+                               query_parameters=params)
+    expect_equal(body$properties$Parameters$foo, "hi")
+    expect_equal(body$db, "Samples")
+    expect_equal(body$csl, "declare query_parameters (foo:string, bar:int, baz:bool, quux:real); MyFunction(foo, bar, baz, quux)")
+})

--- a/tests/testthat/test_query_params.R
+++ b/tests/testthat/test_query_params.R
@@ -2,27 +2,26 @@ context("Building Query Parameters")
 
 test_that("Query parameter types can be assigned appropriately",
 {
-    types <- get_param_types(
-        foo="hi",
+    params <- list(foo="hi",
         bar=1L,
         baz=FALSE,
         quux=1.1,
         dt=as.Date('2019-01-01'))
-
+    types <- AzureKusto:::get_param_types(params)
     expect_equal(
         types,
-        "declare query_parameters (foo:string, bar:int, baz:bool, quux:real, dt:datetime); ")
+        "declare query_parameters (foo:string, bar:int, baz:bool, quux:real, dt:datetime);")
 })
 
 test_that("build_request_body without params gives expected result",
 {
-    body <- build_request_body("Samples", "StormEvents | take 5")
+    body <- AzureKusto:::build_request_body("Samples", "StormEvents | take 5")
     expect_null(body$properties$Parameters)
     expect_equal(body$db, "Samples")
     expect_equal(body$csl, "StormEvents | take 5")
 })
 
-test_that("build_request_body without params gives expected result",
+test_that("build_request_body with params gives expected result",
 {
     params <- list(
         foo="hi",
@@ -30,7 +29,7 @@ test_that("build_request_body without params gives expected result",
         baz=FALSE,
         quux=1.1
     )
-    body <- build_request_body("Samples",
+    body <- AzureKusto:::build_request_body("Samples",
                                "MyFunction(foo, bar, baz, quux)",
                                query_parameters=params)
     expect_equal(body$properties$Parameters$foo, "hi")

--- a/tests/testthat/test_query_params.R
+++ b/tests/testthat/test_query_params.R
@@ -1,0 +1,15 @@
+context("Building Query Parameters")
+
+test_that("Query parameter types can be assigned appropriately",
+{
+    types <- get_param_types(
+        foo="hi",
+        bar=1L,
+        baz=FALSE,
+        quux=1.1,
+        dt=as.Date('2019-01-01'))
+
+    expect_equal(
+        types,
+        "declare query_parameters (foo:string, bar:int, baz:bool, quux:real, dt:datetime); ")
+})


### PR DESCRIPTION
Added query parameter handling for `run_query` and `tbl_kusto` to address #13 . Added usage examples to the README.

The implementation takes advantage of the Kusto REST API's built-in support for query parameterization: https://docs.microsoft.com/en-us/azure/kusto/query/queryparametersstatement

I refactored `call_kusto` a little, because I needed to test building the request body separately from sending the HTTP request.

Also, the `response_dynamic_serialization` property seemed to be defaulting to "json" when unspecified, and I was getting bad query results for dynamic columns. I fixed that by explicitly setting it to "string".