### PR TITLE
Support common tenant

### DIFF
--- a/R/endpoint.R
+++ b/R/endpoint.R
@@ -195,7 +195,7 @@ find_endpoint_token <- function(properties, .query_token)
         auth_type <- "client_credentials"
     }
 
-    return(AzureRMR::get_azure_token(properties$server, tenant=properties$tenantid,
+    return(get_kusto_token(properties$server, tenant=properties$tenantid,
         app=properties$appclientid, password=token_pwd, username=token_user, auth_type=auth_type))
 }
 

--- a/R/kusto_token.R
+++ b/R/kusto_token.R
@@ -25,9 +25,13 @@
 #' @seealso
 #' [kusto_database_endpoint], [AzureAuth::get_azure_token]
 #' @export
-get_kusto_token <- function(server=NULL, clustername, location=NULL, tenant, app=.kusto_app_id, auth_type=NULL, ...)
+get_kusto_token <- function(server=NULL, clustername, location=NULL, tenant=NULL, app=.kusto_app_id, auth_type=NULL,
+                            ...)
 {
-    tenant <- AzureAuth::normalize_tenant(tenant)
+    tenant <- if(is.null(tenant))
+        "common"
+    else AzureAuth::normalize_tenant(tenant)
+
     if(is.null(server))
     {
         location <- normalize_location(location)
@@ -45,14 +49,17 @@ get_kusto_token <- function(server=NULL, clustername, location=NULL, tenant, app
 
 #' @rdname get_kusto_token
 #' @export
-delete_kusto_token <- function(server=NULL, clustername, location=NULL, tenant, app=.kusto_app_id, auth_type=NULL,
+delete_kusto_token <- function(server=NULL, clustername, location=NULL, tenant=NULL, app=.kusto_app_id, auth_type=NULL,
                                ..., hash=NULL, confirm=TRUE)
 {
     # use hash if provided
     if(!is.null(hash))
         return(AzureAuth::delete_azure_token(hash=hash, confirm=confirm))
 
-    tenant <- AzureAuth::normalize_tenant(tenant)
+    tenant <- if(is.null(tenant))
+        "common"
+    else AzureAuth::normalize_tenant(tenant)
+
     if(is.null(server))
     {
         location <- normalize_location(location)

--- a/R/kusto_token.R
+++ b/R/kusto_token.R
@@ -71,7 +71,7 @@ delete_kusto_token <- function(server=NULL, clustername, location=NULL, tenant=N
     if(is.null(auth_type) && app == .kusto_app_id && (!"username" %in% names(list(...))))
         auth_type <- "device_code"
 
-    AzureAuth::delete_azure_token(server, tenant, app, auth_type=auth_type, confirm=confirm)
+    AzureAuth::delete_azure_token(server, tenant, app, auth_type=auth_type, confirm=confirm, ...)
 }
 
 

--- a/README.md
+++ b/README.md
@@ -10,15 +10,13 @@ You can install the development version from GitHub, via `devtools::install_gith
 
 ### Kusto Endpoint Interface
 
-Connect to a Kusto cluster by instantiating a `kusto_database_endpoint` object with the cluster URI, database name, and an `AzureRMR::AzureToken` object, which you can obtain via the `get_kusto_token` helper function.
+Connect to a Kusto cluster by instantiating a `kusto_database_endpoint` object with the cluster URI and database name.
 
 ```r
 
 library(AzureKusto)
 
-Samples <- kusto_database_endpoint(server="https://help.kusto.windows.net",
-    database="Samples",
-    .query_token=get_kusto_token(clustername="help", tenant="microsoft"))
+Samples <- kusto_database_endpoint(server="https://help.kusto.windows.net", database="Samples")
 
 # To sign in, use a web browser to open the page https://microsoft.com/devicelogin and enter the code FPD8GZPY9 to authenticate.
 # Waiting for device code in browser...

--- a/man/get_kusto_token.Rd
+++ b/man/get_kusto_token.Rd
@@ -6,12 +6,12 @@
 \alias{list_kusto_tokens}
 \title{Manage AAD authentication tokens for Kusto clusters}
 \usage{
-get_kusto_token(server = NULL, clustername, location = NULL, tenant,
-  app = .kusto_app_id, auth_type = NULL, ...)
+get_kusto_token(server = NULL, clustername, location = NULL,
+  tenant = NULL, app = .kusto_app_id, auth_type = NULL, ...)
 
-delete_kusto_token(server = NULL, clustername, location = NULL, tenant,
-  app = .kusto_app_id, auth_type = NULL, ..., hash = NULL,
-  confirm = TRUE)
+delete_kusto_token(server = NULL, clustername, location = NULL,
+  tenant = NULL, app = .kusto_app_id, auth_type = NULL, ...,
+  hash = NULL, confirm = TRUE)
 
 list_kusto_tokens()
 }

--- a/tests/testthat/test00_token.R
+++ b/tests/testthat/test00_token.R
@@ -85,3 +85,14 @@ test_that("Obtaining token from own app works",
     expect_identical(tok1$hash(), tok2$hash())
     expect_identical(tok1$hash(), tok2$hash())
 })
+
+
+# should get one devicecode prompt here
+test_that("Obtaining token for common tenant works",
+{
+    srvuri <- sprintf("https://%s.%s.kusto.windows.net", srvname, srvloc)
+    tok <- get_kusto_token(srvuri)
+    expect_true(AzureAuth::is_azure_token(tok))
+})
+
+Sys.unsetenv("AZ_TEST_KUSTO_TOKEN_HASH")

--- a/tests/testthat/test02_query.R
+++ b/tests/testthat/test02_query.R
@@ -20,6 +20,7 @@ server <- sprintf("https://%s.%s.kusto.windows.net", srvname, srvloc)
 db <- kusto_database_endpoint(server=server, database=dbname, tenantid=tenant)
 db2 <- kusto_database_endpoint(server=server, database=dbname, tenantid=tenant,
     appclientid=app, appkey=password)
+db3 <- kusto_database_endpoint(server=server, database=dbname)
 
 test_that("Queries work",
 {
@@ -57,6 +58,26 @@ test_that("Commands work with own app",
     expect_is(out, "data.frame")
 
     dberr <- db2
+    dberr$token <- NULL
+    expect_error(run_query(dberr, ".show cluster"))
+})
+
+test_that("Queries work with common tenant",
+{
+    out <- run_query(db3, "iris | summarize count() by species")
+    expect_is(out, "data.frame")
+
+    dberr <- db3
+    dberr$token <- NULL
+    expect_error(run_query(dberr, "iris | summarize count() by species"))
+})
+
+test_that("Commands work with common tenant",
+{
+    out <- run_query(db3, ".show cluster")
+    expect_is(out, "data.frame")
+
+    dberr <- db3
     dberr$token <- NULL
     expect_error(run_query(dberr, ".show cluster"))
 })


### PR DESCRIPTION
This PR lets you omit the tenantid when requesting a token or creating a database endpoint object. It works by authenticating via the `common` tenant/endpoint in AAD, which will infer your actual tenant from your credentials.

```r
# these work now
token <= get_kusto_token("https://myclust.region.kusto.windows.net")

endp <- kusto_database_endpoint(server="https://myclust.region.kusto.windows.net", database="mydb")
```