### PR TITLE
Support cross-cluster joining with dplyr interface

### DIFF
--- a/R/ingest.R
+++ b/R/ingest.R
@@ -25,9 +25,10 @@
 #' # ingesting from local:
 #'
 #' # ingest via Azure storage
-#' cont <- AzureStor::storage_container("https://mystorage.blob.core.windows.net/container", sas="mysas")
+#' cont <- AzureStor::storage_container("https://mystorage.blob.core.windows.net/container",
+#'     sas="mysas")
 #' ingest_local(db, "file.csv", "table",
-#'              method="indirect", storage_container=cont)
+#'     method="indirect", storage_container=cont)
 #'
 #  # ingest by streaming
 #' ingest_local(db, "file.csv", "table", method="streaming")
@@ -39,21 +40,21 @@
 #'
 #' # a public dataset: Microsoft web data from UCI machine learning repository
 #' ingest_url(db,
-#'            "https://archive.ics.uci.edu/ml/machine-learning-databases/anonymous/anonymous-msweb.data",
-#'            "table")
+#'     "https://archive.ics.uci.edu/ml/machine-learning-databases/anonymous/anonymous-msweb.data",
+#'     "table")
 #'
 #' # from blob storage:
 #' ingest_blob(db,
-#'             "https://mystorage.blob.core.windows.net/container/myblob",
-#'             "table",
-#'             sas="mysas")
+#'     "https://mystorage.blob.core.windows.net/container/myblob",
+#'     "table",
+#'     sas="mysas")
 #'
 #' # from ADLSGen2:
 #' token <- AzureRMR::get_azure_token("https://storage.azure.com", "mytenant", "myapp", "password")
 #' ingest_blob(db,
-#'             "abfss://filesystem@myadls2.dfs.core.windows.net/data/myfile",
-#'             "table",
-#'             token=token)
+#'     "abfss://filesystem@myadls2.dfs.core.windows.net/data/myfile",
+#'     "table",
+#'     token=token)
 #'
 #' }
 #' @rdname ingest

--- a/R/kql-build.R
+++ b/R/kql-build.R
@@ -211,6 +211,10 @@ kql_build.op_join <- function(op, ...)
         stop(".num_partitions must be a number", .call=FALSE)
     else NULL
 
+    .remote <- if(!is.null(op$args$.remote))
+        paste0(" hint.remote = ", op$args$.remote, collapse="")
+    else NULL
+
     kind <- switch(join_type,
         inner_join="inner",
         left_join="leftouter",
@@ -222,7 +226,8 @@ kql_build.op_join <- function(op, ...)
     )
 
     # paste(c(*), collapse="") will not insert extra spaces when NULLs present
-    join_str <- ident_q(paste(c("join kind = ", kind, .strategy, .shufflekeys, .num_partitions, " "), collapse=""))
+    join_str <- ident_q(paste(c("join kind = ", kind, .strategy, .shufflekeys, .num_partitions, .remote, " "),
+        collapse=""))
     build_kql(join_str, "(", y_render, ") on ", by_clause)
 }
 

--- a/R/kql-render.R
+++ b/R/kql-render.R
@@ -10,7 +10,8 @@ kql_render <- function(query, ...)
 #' @export
 kql_render.kql_query <- function(query, ...)
 {
-    tblname <- sprintf("database('%s').%s", query$src$database, kql(query$src$table))
+    tblname <- sprintf("cluster('%s').database('%s').%s", query$src$server,
+        query$src$database, kql(query$src$table))
     q_str <- paste(unlist(query$ops[-1]), collapse = "\n| ")
 
     if (nchar(q_str) > 0)

--- a/R/ops.R
+++ b/R/ops.R
@@ -86,9 +86,10 @@ op_double <- function(name, x, y, args = list())
 #' @param suffix  A vector of strings that will be appended to the names of non-join key columns that exist in both tbl x and tbl y to distinguish them by source tbl.
 #' @param .strategy A strategy hint to provide to Kusto.
 #' @param .shufflekeys A character vector of column names to shuffle on, if `.strategy = "shuffle"`.
+#' @param .remote A strategy hint to provide to Kusto for cross-cluster joins.
 #' @param .num_partitions The number of partitions for a shuffle query.
 add_op_join <- function(type, x, y, by = NULL, suffix = NULL,
-                       .strategy = NULL, .shufflekeys = NULL, .num_partitions = NULL)
+                       .strategy = NULL, .shufflekeys = NULL, .num_partitions = NULL, .remote = NULL)
 {
     by <- common_by(by, x, y)
     vars <- join_vars(op_vars(x), op_vars(y), type = type, by = by, suffix = suffix)
@@ -100,7 +101,8 @@ add_op_join <- function(type, x, y, by = NULL, suffix = NULL,
                            suffix = suffix,
                            .strategy = .strategy,
                            .shufflekeys = .shufflekeys,
-                           .num_partitions = .num_partitions
+                           .num_partitions = .num_partitions,
+                           .remote = .remote
                        ))
     x
 }

--- a/R/tbl.R
+++ b/R/tbl.R
@@ -153,6 +153,7 @@ head.tbl_kusto_abstract <- function(x, n = 6L, ...)
 #' @param .strategy A join strategy hint to pass to Kusto. Currently the values supported are "shuffle" and "broadcast".
 #' @param .shufflekeys A character vector of column names to use as shuffle keys.
 #' @param .num_partitions The number of partitions for a shuffle query.
+#' @param .remote A join strategy hint to use for cross-cluster joins. Can be "left", "right", "local" or "auto" (the default).
 #' @param ... Other arguments passed to lower-level functions.
 #' @seealso
 #' [dplyr::join]
@@ -179,57 +180,69 @@ head.tbl_kusto_abstract <- function(x, n = 6L, ...)
 #' @rdname join
 #' @export
 inner_join.tbl_kusto_abstract <- function(x, y, by = NULL, suffix = c(".x", ".y"),
-                                          .strategy = NULL, .shufflekeys = NULL, .num_partitions = NULL, ...)
+                                          .strategy = NULL, .shufflekeys = NULL, .num_partitions = NULL,
+                                          .remote = NULL, ...)
 {
     add_op_join("inner_join", x, y, by = by, suffix = suffix,
-                .strategy = .strategy, .shufflekeys = .shufflekeys, .num_partitions = .num_partitions, ...)
+                .strategy = .strategy, .shufflekeys = .shufflekeys, .num_partitions = .num_partitions,
+                .remote = .remote, ...)
 }
 
 #' @rdname join
 #' @export
 left_join.tbl_kusto_abstract <- function(x, y, by = NULL, suffix = c(".x", ".y"),
-                                         .strategy = NULL, .shufflekeys = NULL, .num_partitions = NULL, ...)
+                                         .strategy = NULL, .shufflekeys = NULL, .num_partitions = NULL,
+                                         .remote = .NULL, ...)
 {
     add_op_join("left_join", x, y, by = by, suffix = suffix,
-                .strategy = .strategy, .shufflekeys = .shufflekeys, .num_partitions = .num_partitions, ...)
+                .strategy = .strategy, .shufflekeys = .shufflekeys, .num_partitions = .num_partitions,
+                .remote = .remote, ...)
 }
 
 #' @rdname join
 #' @export
 right_join.tbl_kusto_abstract <- function(x, y, by = NULL, suffix = c(".x", ".y"),
-                                          .strategy = NULL, .shufflekeys = NULL, .num_partitions = NULL, ...)
+                                          .strategy = NULL, .shufflekeys = NULL, .num_partitions = NULL,
+                                          .remote = NULL, ...)
 {
     add_op_join("right_join", x, y, by = by, suffix = suffix,
-                .strategy = .strategy, .shufflekeys = .shufflekeys, .num_partitions = .num_partitions, ...)
+                .strategy = .strategy, .shufflekeys = .shufflekeys, .num_partitions = .num_partitions,
+                .remote = .remote, ...)
 }
 
 #' @rdname join
 #' @export
 full_join.tbl_kusto_abstract <- function(x, y, by = NULL, suffix = c(".x", ".y"),
-                                         .strategy = NULL, .shufflekeys = NULL, .num_partitions = NULL, ...)
+                                         .strategy = NULL, .shufflekeys = NULL, .num_partitions = NULL,
+                                         .remote = NULL, ...)
 
 {
     add_op_join("full_join", x, y, by = by, suffix = suffix,
-                .strategy = .strategy, .shufflekeys = .shufflekeys, .num_partitions = .num_partitions, ...)
+                .strategy = .strategy, .shufflekeys = .shufflekeys, .num_partitions = .num_partitions,
+                .remote = .remote, ...)
 }
 
 #' @rdname join
 #' @export
 semi_join.tbl_kusto_abstract <- function(x, y, by = NULL, suffix = c(".x", ".y"),
-                                         .strategy = NULL, .shufflekeys = NULL, .num_partitions = NULL, ...)
+                                         .strategy = NULL, .shufflekeys = NULL, .num_partitions = NULL,
+                                         .remote = NULL, ...)
 
 {
     add_op_join("semi_join", x, y, by = by, suffix = suffix,
-                .strategy = .strategy, .shufflekeys = .shufflekeys, .num_partitions = .num_partitions, ...)
+                .strategy = .strategy, .shufflekeys = .shufflekeys, .num_partitions = .num_partitions,
+                .remote = .remote, ...)
 }
 
 #' @rdname join
 #' @export
 anti_join.tbl_kusto_abstract <- function(x, y, by = NULL, suffix = c(".x", ".y"),
-                                         .strategy = NULL, .shufflekeys = NULL, .num_partitions = NULL, ...)
+                                         .strategy = NULL, .shufflekeys = NULL, .num_partitions = NULL,
+                                         .remote = NULL, ...)
 {
     add_op_join("anti_join", x, y, by = by, suffix = suffix,
-                .strategy = .strategy, .shufflekeys = .shufflekeys, .num_partitions = .num_partitions, ...)
+                .strategy = .strategy, .shufflekeys = .shufflekeys, .num_partitions = .num_partitions,
+                .remote = .remote, ...)
 }
 
 #' @export

--- a/R/tbl.R
+++ b/R/tbl.R
@@ -192,7 +192,7 @@ inner_join.tbl_kusto_abstract <- function(x, y, by = NULL, suffix = c(".x", ".y"
 #' @export
 left_join.tbl_kusto_abstract <- function(x, y, by = NULL, suffix = c(".x", ".y"),
                                          .strategy = NULL, .shufflekeys = NULL, .num_partitions = NULL,
-                                         .remote = .NULL, ...)
+                                         .remote = NULL, ...)
 {
     add_op_join("left_join", x, y, by = by, suffix = suffix,
                 .strategy = .strategy, .shufflekeys = .shufflekeys, .num_partitions = .num_partitions,

--- a/man/add_op_join.Rd
+++ b/man/add_op_join.Rd
@@ -5,7 +5,7 @@
 \title{Append a join operation to the tbl_kusto object's ops list}
 \usage{
 add_op_join(type, x, y, by = NULL, suffix = NULL, .strategy = NULL,
-  .shufflekeys = NULL, .num_partitions = NULL)
+  .shufflekeys = NULL, .num_partitions = NULL, .remote = NULL)
 }
 \arguments{
 \item{type}{The name of the join type,
@@ -24,6 +24,8 @@ one of: inner_join, left_join, right_join, full_join, semi_join, anti_join}
 \item{.shufflekeys}{A character vector of column names to shuffle on, if \code{.strategy = "shuffle"}.}
 
 \item{.num_partitions}{The number of partitions for a shuffle query.}
+
+\item{.remote}{A strategy hint to provide to Kusto for cross-cluster joins.}
 }
 \description{
 Append a join operation to the tbl_kusto object's ops list

--- a/man/ingest.Rd
+++ b/man/ingest.Rd
@@ -63,9 +63,10 @@ Note that the destination table must be created ahead of time for the ingestion 
 # ingesting from local:
 
 # ingest via Azure storage
-cont <- AzureStor::storage_container("https://mystorage.blob.core.windows.net/container", sas="mysas")
+cont <- AzureStor::storage_container("https://mystorage.blob.core.windows.net/container",
+    sas="mysas")
 ingest_local(db, "file.csv", "table",
-             method="indirect", storage_container=cont)
+    method="indirect", storage_container=cont)
 
 ingest_local(db, "file.csv", "table", method="streaming")
 
@@ -76,21 +77,21 @@ ingest_inline(db, "file.csv", "table", method="inline")
 
 # a public dataset: Microsoft web data from UCI machine learning repository
 ingest_url(db,
-           "https://archive.ics.uci.edu/ml/machine-learning-databases/anonymous/anonymous-msweb.data",
-           "table")
+    "https://archive.ics.uci.edu/ml/machine-learning-databases/anonymous/anonymous-msweb.data",
+    "table")
 
 # from blob storage:
 ingest_blob(db,
-            "https://mystorage.blob.core.windows.net/container/myblob",
-            "table",
-            sas="mysas")
+    "https://mystorage.blob.core.windows.net/container/myblob",
+    "table",
+    sas="mysas")
 
 # from ADLSGen2:
 token <- AzureRMR::get_azure_token("https://storage.azure.com", "mytenant", "myapp", "password")
 ingest_blob(db,
-            "abfss://filesystem@myadls2.dfs.core.windows.net/data/myfile",
-            "table",
-            token=token)
+    "abfss://filesystem@myadls2.dfs.core.windows.net/data/myfile",
+    "table",
+    token=token)
 
 }
 }

--- a/man/join.Rd
+++ b/man/join.Rd
@@ -21,7 +21,7 @@
 
 \method{left_join}{tbl_kusto_abstract}(x, y, by = NULL,
   suffix = c(".x", ".y"), .strategy = NULL, .shufflekeys = NULL,
-  .num_partitions = NULL, .remote = .NULL, ...)
+  .num_partitions = NULL, .remote = NULL, ...)
 
 \method{right_join}{tbl_kusto_abstract}(x, y, by = NULL,
   suffix = c(".x", ".y"), .strategy = NULL, .shufflekeys = NULL,

--- a/man/join.Rd
+++ b/man/join.Rd
@@ -17,27 +17,27 @@
 \usage{
 \method{inner_join}{tbl_kusto_abstract}(x, y, by = NULL,
   suffix = c(".x", ".y"), .strategy = NULL, .shufflekeys = NULL,
-  .num_partitions = NULL, ...)
+  .num_partitions = NULL, .remote = NULL, ...)
 
 \method{left_join}{tbl_kusto_abstract}(x, y, by = NULL,
   suffix = c(".x", ".y"), .strategy = NULL, .shufflekeys = NULL,
-  .num_partitions = NULL, ...)
+  .num_partitions = NULL, .remote = .NULL, ...)
 
 \method{right_join}{tbl_kusto_abstract}(x, y, by = NULL,
   suffix = c(".x", ".y"), .strategy = NULL, .shufflekeys = NULL,
-  .num_partitions = NULL, ...)
+  .num_partitions = NULL, .remote = NULL, ...)
 
 \method{full_join}{tbl_kusto_abstract}(x, y, by = NULL,
   suffix = c(".x", ".y"), .strategy = NULL, .shufflekeys = NULL,
-  .num_partitions = NULL, ...)
+  .num_partitions = NULL, .remote = NULL, ...)
 
 \method{semi_join}{tbl_kusto_abstract}(x, y, by = NULL,
   suffix = c(".x", ".y"), .strategy = NULL, .shufflekeys = NULL,
-  .num_partitions = NULL, ...)
+  .num_partitions = NULL, .remote = NULL, ...)
 
 \method{anti_join}{tbl_kusto_abstract}(x, y, by = NULL,
   suffix = c(".x", ".y"), .strategy = NULL, .shufflekeys = NULL,
-  .num_partitions = NULL, ...)
+  .num_partitions = NULL, .remote = NULL, ...)
 }
 \arguments{
 \item{x, y}{Kusto tbls.}
@@ -51,6 +51,8 @@
 \item{.shufflekeys}{A character vector of column names to use as shuffle keys.}
 
 \item{.num_partitions}{The number of partitions for a shuffle query.}
+
+\item{.remote}{A join strategy hint to use for cross-cluster joins. Can be "left", "right", "local" or "auto" (the default).}
 
 \item{...}{Other arguments passed to lower-level functions.}
 }

--- a/tests/testthat/test06_dplyr.R
+++ b/tests/testthat/test06_dplyr.R
@@ -148,3 +148,23 @@ test_that("parameterised queries work",
     out <- dplyr::collect(dplyr::mutate(ir_parm, species2=parm))
     expect_true(inherits(out, "tbl_df") && all(out$species2 == "setosa") && nrow(out) == 150)
 })
+
+test_that("cross-cluster joins work",
+{
+    srvname2 <- Sys.getenv("AZ_TEST_KUSTO_SERVER2")
+    srvloc2 <- Sys.getenv("AZ_TEST_KUSTO_SERVER2_LOCATION")
+    dbname2 <- Sys.getenv("AZ_TEST_KUSTO_DATABASE2")
+    
+    if(srvname2 == "" || srvloc2 == "" || dbname2 == "")
+        skip("Cross-cluster join tests skipped: server info not set")
+
+    server2 <- sprintf("https://%s.%s.kusto.windows.net", srvname2, srvloc2)
+
+    db2 <- kusto_database_endpoint(server=server2, database=dbname2, tenantid=tenant,
+        appclientid=app, appkey=password)
+
+    spec <- tbl_kusto(db2, "species")
+
+    out <- dplyr::collect(dplyr::left_join(ir, spec))
+    expect_true(inherits(out, "tbl_df") && nrow(out) == 150)
+})

--- a/tests/testthat/test06_dplyr.R
+++ b/tests/testthat/test06_dplyr.R
@@ -167,4 +167,10 @@ test_that("cross-cluster joins work",
 
     out <- dplyr::collect(dplyr::left_join(ir, spec))
     expect_true(inherits(out, "tbl_df") && nrow(out) == 150)
+
+    out <- dplyr::collect(dplyr::left_join(ir, spec, .remote="left"))
+    expect_true(inherits(out, "tbl_df") && nrow(out) == 150)
+
+    out <- dplyr::collect(dplyr::left_join(ir, spec, .remote="right"))
+    expect_true(inherits(out, "tbl_df") && nrow(out) == 150)
 })

--- a/tests/testthat/test_translate.r
+++ b/tests/testthat/test_translate.r
@@ -1,14 +1,14 @@
 context("translate")
 
 
-tbl_iris <- tibble::as.tibble(iris)
+tbl_iris <- tibble::as_tibble(iris)
 names(tbl_iris) <- c("SepalLength", "SepalWidth", "PetalLength", "PetalWidth", "Species")
 tbl_iris <- tbl_kusto_abstract(tbl_iris, "iris")
 
 
 test_that("params to a function can be used inside a mutate expressions",
 {
-    tbl_iris_p <- tibble::as.tibble(iris)
+    tbl_iris_p <- tibble::as_tibble(iris)
     names(tbl_iris_p) <- c("SepalLength", "SepalWidth", "PetalLength", "PetalWidth", "Species")
     tbl_iris_p <- tbl_kusto_abstract(tbl_iris, "iris", p="setosa")
     
@@ -17,20 +17,20 @@ test_that("params to a function can be used inside a mutate expressions",
     
     q_str <- show_query(q)
 
-    expect_equal(q_str, kql("database('local_df').['iris']\n| extend ['Species'] = 'setosa'"))
+    expect_equal(q_str, kql("cluster('local_df').database('local_df').['iris']\n| extend ['Species'] = 'setosa'"))
 })
 
 test_that("params to a function can be used inside a filter expressions",
 {
     
-    tbl_iris_p <- tibble::as.tibble(iris)
+    tbl_iris_p <- tibble::as_tibble(iris)
     names(tbl_iris_p) <- c("SepalLength", "SepalWidth", "PetalLength", "PetalWidth", "Species")
     tbl_iris_p <- tbl_kusto_abstract(tbl_iris_p, "iris", p="setosa")
     
     q <- filter(tbl_iris_p, Species == p)
     q_str <- show_query(q)
 
-    expect_equal(q_str, kql("database('local_df').['iris']\n| where ['Species'] == 'setosa'"))
+    expect_equal(q_str, kql("cluster('local_df').database('local_df').['iris']\n| where ['Species'] == 'setosa'"))
 })
 
 
@@ -40,7 +40,7 @@ test_that("select is translated to project",
         dplyr::select(Species, SepalLength) %>%
         show_query()
 
-    expect_equal(q, kql("database('local_df').['iris']\n| project ['Species'], ['SepalLength']"))
+    expect_equal(q, kql("cluster('local_df').database('local_df').['iris']\n| project ['Species'], ['SepalLength']"))
 })
 
 test_that("distinct is translated to distinct",
@@ -49,7 +49,7 @@ test_that("distinct is translated to distinct",
         dplyr::distinct(Species, SepalLength) %>%
         show_query()
 
-    expect_equal(q, kql("database('local_df').['iris']\n| distinct ['Species'], ['SepalLength']"))
+    expect_equal(q, kql("cluster('local_df').database('local_df').['iris']\n| distinct ['Species'], ['SepalLength']"))
 })
 
 test_that("kql_infix formats correctly",
@@ -74,7 +74,7 @@ test_that("filter is translated to where with a single expression",
     q_str <- q %>%
         show_query()
 
-    expect_equal(q_str, kql("database('local_df').['iris']\n| where ['Species'] == 'setosa'"))
+    expect_equal(q_str, kql("cluster('local_df').database('local_df').['iris']\n| where ['Species'] == 'setosa'"))
 })
 
 test_that("multiple arguments to filter() become multiple where clauses",
@@ -85,7 +85,7 @@ test_that("multiple arguments to filter() become multiple where clauses",
     q_str <- q %>%
         show_query()
 
-    expect_equal(q_str, kql("database('local_df').['iris']\n| where ['Species'] == 'setosa'\n| where ['SepalLength'] > 4.1"))
+    expect_equal(q_str, kql("cluster('local_df').database('local_df').['iris']\n| where ['Species'] == 'setosa'\n| where ['SepalLength'] > 4.1"))
 })
 
 test_that("filter errors on missing symbols",
@@ -104,7 +104,7 @@ test_that("variables from enclosing environment are passed to filter()",
 
     q_str <- show_query(q)
 
-    expect_equal(q_str, kql("database('local_df').['iris']\n| where ['SepalLength'] <= 2.5"))
+    expect_equal(q_str, kql("cluster('local_df').database('local_df').['iris']\n| where ['SepalLength'] <= 2.5"))
 })
 
 test_that("variables from enclosing environment are passed to mutate()",
@@ -115,7 +115,7 @@ test_that("variables from enclosing environment are passed to mutate()",
 
     q_str <- show_query(q)
 
-    expect_equal(q_str, kql("database('local_df').['iris']\n| extend ['SepalLengthLimit'] = 2.5"))
+    expect_equal(q_str, kql("cluster('local_df').database('local_df').['iris']\n| extend ['SepalLengthLimit'] = 2.5"))
 })
 
 test_that("select and filter can be combined",
@@ -127,7 +127,7 @@ test_that("select and filter can be combined",
     q_str <- q %>%
         show_query()
 
-    expect_equal(q_str, kql("database('local_df').['iris']\n| where ['Species'] == 'setosa'\n| project ['Species'], ['SepalLength']"))
+    expect_equal(q_str, kql("cluster('local_df').database('local_df').['iris']\n| where ['Species'] == 'setosa'\n| project ['Species'], ['SepalLength']"))
 })
 
 test_that("select errors on column after selected away",
@@ -147,7 +147,7 @@ test_that("mutate translates to extend",
     q_str <- q %>%
         show_query()
 
-    expect_equal(q_str, kql("database('local_df').['iris']\n| extend ['Species2'] = ['Species']"))
+    expect_equal(q_str, kql("cluster('local_df').database('local_df').['iris']\n| extend ['Species2'] = ['Species']"))
 })
 
 test_that("multiple arguments to mutate() become multiple extend clauses",
@@ -158,7 +158,7 @@ test_that("multiple arguments to mutate() become multiple extend clauses",
     q_str <- q %>%
         show_query()
 
-    expect_equal(q_str, kql("database('local_df').['iris']\n| extend ['Species2'] = ['Species']\n| extend ['Species3'] = ['Species2']\n| extend ['Foo'] = 1 + 2"))
+    expect_equal(q_str, kql("cluster('local_df').database('local_df').['iris']\n| extend ['Species2'] = ['Species']\n| extend ['Species3'] = ['Species2']\n| extend ['Foo'] = 1 + 2"))
 })
 
 test_that("sum() translated correctly",
@@ -176,7 +176,7 @@ test_that("arrange() generates order by ",
     q_str <- q %>%
         show_query()
 
-    expect_equal(q_str, kql("database('local_df').['iris']\n| order by ['Species'] asc, ['SepalLength'] desc"))
+    expect_equal(q_str, kql("cluster('local_df').database('local_df').['iris']\n| order by ['Species'] asc, ['SepalLength'] desc"))
 })
 
 test_that("group_by() followed by summarize() generates summarize clause",
@@ -188,7 +188,7 @@ test_that("group_by() followed by summarize() generates summarize clause",
 
     q_str <- q %>% show_query()
 
-    expect_equal(q_str, kql("database('local_df').['iris']\n| summarize ['MaxSepalLength'] = max(['SepalLength']) by ['Species']"))
+    expect_equal(q_str, kql("cluster('local_df').database('local_df').['iris']\n| summarize ['MaxSepalLength'] = max(['SepalLength']) by ['Species']"))
 })
 
 test_that("group_by() followed by ungroup() followed by summarize() generates summarize clause",
@@ -202,7 +202,7 @@ test_that("group_by() followed by ungroup() followed by summarize() generates su
 
     q_str <- q %>% show_query()
 
-    expect_equal(q_str, kql("database('local_df').['iris']\n| summarize ['MaxSepalLength'] = max(['SepalLength']) by ['Species']\n| summarize ['MeanOfMaxSepalLength'] = avg(['MaxSepalLength'])"))
+    expect_equal(q_str, kql("cluster('local_df').database('local_df').['iris']\n| summarize ['MaxSepalLength'] = max(['SepalLength']) by ['Species']\n| summarize ['MeanOfMaxSepalLength'] = avg(['MaxSepalLength'])"))
 })
 
 test_that("group_by() followed by mutate() partitions the mutation by the grouping variables",
@@ -214,7 +214,7 @@ test_that("group_by() followed by mutate() partitions the mutation by the groupi
 
     q_str <- q %>% show_query()
 
-    expect_equal(q_str, kql("database('local_df').['iris']\n| as tmp | join kind=leftouter (tmp | summarize ['SpeciesMaxSepalLength'] = max(['SepalLength']) by ['Species']) on ['Species']\n| project ['SepalLength'], ['SepalWidth'], ['PetalLength'], ['PetalWidth'], ['Species'], ['SpeciesMaxSepalLength']"))
+    expect_equal(q_str, kql("cluster('local_df').database('local_df').['iris']\n| as tmp | join kind=leftouter (tmp | summarize ['SpeciesMaxSepalLength'] = max(['SepalLength']) by ['Species']) on ['Species']\n| project ['SepalLength'], ['SepalWidth'], ['PetalLength'], ['PetalWidth'], ['Species'], ['SpeciesMaxSepalLength']"))
 })
 
 test_that("mutate() with an agg function and no group_by() groups by all other columns",
@@ -224,7 +224,7 @@ test_that("mutate() with an agg function and no group_by() groups by all other c
 
     q_str <- q %>% show_query()
 
-    expect_equal(q_str, kql("database('local_df').['iris']\n| summarize ['MaxSepalLength'] = max(['SepalLength']) by ['SepalLength'], ['SepalWidth'], ['PetalLength'], ['PetalWidth'], ['Species']"))
+    expect_equal(q_str, kql("cluster('local_df').database('local_df').['iris']\n| summarize ['MaxSepalLength'] = max(['SepalLength']) by ['SepalLength'], ['SepalWidth'], ['PetalLength'], ['PetalWidth'], ['Species']"))
 })
 
 test_that("is_agg works with symbols and strings",
@@ -245,7 +245,7 @@ test_that("rename() renames variables",
 
     q_str <- q %>% show_query()
 
-    expect_equal(q_str, kql("database('local_df').['iris']\n| project-rename ['Species2'] = ['Species'], ['SepalLength2'] = ['SepalLength']"))
+    expect_equal(q_str, kql("cluster('local_df').database('local_df').['iris']\n| project-rename ['Species2'] = ['Species'], ['SepalLength2'] = ['SepalLength']"))
 })
 
 test_that("rename() errors when given a nonexistent column",
@@ -263,7 +263,7 @@ test_that("head(10) translates to take 10",
 
     q_str <- q %>% show_query()
 
-    expect_equal(q_str, kql("database('local_df').['iris']\n| take 10"))
+    expect_equal(q_str, kql("cluster('local_df').database('local_df').['iris']\n| take 10"))
 })
 
 test_that("head() translates to take 6 (the default)",
@@ -273,7 +273,7 @@ test_that("head() translates to take 6 (the default)",
 
     q_str <- q %>% show_query
 
-    expect_equal(q_str, kql("database('local_df').['iris']\n| take 6"))
+    expect_equal(q_str, kql("cluster('local_df').database('local_df').['iris']\n| take 6"))
 })
 
 left <- tbl_iris
@@ -302,7 +302,7 @@ test_that("inner_join() on a single column translates correctly",
 
     q_str <- show_query(q)
 
-    expect_equal(q_str, kql("database('local_df').['iris']\n| join kind = inner (database('local_df').['iris2']) on ['Species']"))
+    expect_equal(q_str, kql("cluster('local_df').database('local_df').['iris']\n| join kind = inner (cluster('local_df').database('local_df').['iris2']) on ['Species']"))
 })
 
 test_that("inner_join() on two columns translates correctly",
@@ -312,7 +312,7 @@ test_that("inner_join() on two columns translates correctly",
 
     q_str <- show_query(q)
 
-    expect_equal(q_str, kql("database('local_df').['iris']\n| join kind = inner (database('local_df').['iris2']) on ['Species'], ['SepalWidth']"))
+    expect_equal(q_str, kql("cluster('local_df').database('local_df').['iris']\n| join kind = inner (cluster('local_df').database('local_df').['iris2']) on ['Species'], ['SepalWidth']"))
 })
 
 test_that("inner_join() on one differently named column translates correctly",
@@ -322,7 +322,7 @@ test_that("inner_join() on one differently named column translates correctly",
 
     q_str <- show_query(q)
 
-    expect_equal(q_str, kql("database('local_df').['iris']\n| join kind = inner (database('local_df').['iris3']) on $left.['Species'] == $right.['Species2']"))
+    expect_equal(q_str, kql("cluster('local_df').database('local_df').['iris']\n| join kind = inner (cluster('local_df').database('local_df').['iris3']) on $left.['Species'] == $right.['Species2']"))
 })
 
 test_that("inner_join() on two differently named columns translates correctly",
@@ -333,7 +333,7 @@ test_that("inner_join() on two differently named columns translates correctly",
 
     q_str <- show_query(q)
 
-    expect_equal(q_str, kql("database('local_df').['iris']\n| join kind = inner (database('local_df').['iris3']) on $left.['Species'] == $right.['Species2'], $left.['SepalWidth'] == $right.['SepalWidth2']"))
+    expect_equal(q_str, kql("cluster('local_df').database('local_df').['iris']\n| join kind = inner (cluster('local_df').database('local_df').['iris3']) on $left.['Species'] == $right.['Species2'], $left.['SepalWidth'] == $right.['SepalWidth2']"))
 })
 
 test_that("left_join() on a single column translates correctly",
@@ -344,7 +344,7 @@ test_that("left_join() on a single column translates correctly",
 
     q_str <- show_query(q)
 
-    expect_equal(q_str, kql("database('local_df').['iris']\n| join kind = leftouter (database('local_df').['iris2']) on ['Species']"))
+    expect_equal(q_str, kql("cluster('local_df').database('local_df').['iris']\n| join kind = leftouter (cluster('local_df').database('local_df').['iris2']) on ['Species']"))
 })
 
 test_that("right_join() on a single column translates correctly",
@@ -355,7 +355,7 @@ test_that("right_join() on a single column translates correctly",
 
     q_str <- show_query(q)
 
-    expect_equal(q_str, kql("database('local_df').['iris']\n| join kind = rightouter (database('local_df').['iris2']) on ['Species']"))
+    expect_equal(q_str, kql("cluster('local_df').database('local_df').['iris']\n| join kind = rightouter (cluster('local_df').database('local_df').['iris2']) on ['Species']"))
 })
 
 test_that("full_join() on a single column translates correctly",
@@ -366,7 +366,7 @@ test_that("full_join() on a single column translates correctly",
 
     q_str <- show_query(q)
 
-    expect_equal(q_str, kql("database('local_df').['iris']\n| join kind = fullouter (database('local_df').['iris2']) on ['Species']"))
+    expect_equal(q_str, kql("cluster('local_df').database('local_df').['iris']\n| join kind = fullouter (cluster('local_df').database('local_df').['iris2']) on ['Species']"))
 })
 
 test_that("semi_join() on a single column translates correctly",
@@ -377,7 +377,7 @@ test_that("semi_join() on a single column translates correctly",
 
     q_str <- show_query(q)
 
-    expect_equal(q_str, kql("database('local_df').['iris']\n| join kind = leftsemi (database('local_df').['iris2']) on ['Species']"))
+    expect_equal(q_str, kql("cluster('local_df').database('local_df').['iris']\n| join kind = leftsemi (cluster('local_df').database('local_df').['iris2']) on ['Species']"))
 })
 
 test_that("anti_join() on a single column translates correctly",
@@ -388,7 +388,7 @@ test_that("anti_join() on a single column translates correctly",
 
     q_str <- show_query(q)
 
-    expect_equal(q_str, kql("database('local_df').['iris']\n| join kind = leftanti (database('local_df').['iris2']) on ['Species']"))
+    expect_equal(q_str, kql("cluster('local_df').database('local_df').['iris']\n| join kind = leftanti (cluster('local_df').database('local_df').['iris2']) on ['Species']"))
 })
 
 test_that("union_all translates correctly",
@@ -400,7 +400,7 @@ test_that("union_all translates correctly",
 
     q_str <- show_query(q)
 
-    expect_equal(q_str, kql("database('local_df').['iris']\n| union kind = outer (database('local_df').['iris'])"))
+    expect_equal(q_str, kql("cluster('local_df').database('local_df').['iris']\n| union kind = outer (cluster('local_df').database('local_df').['iris'])"))
 
 })
 
@@ -419,7 +419,7 @@ test_that("as.Date() produces a Kusto datetime",
 
     q_str <- show_query(q)
 
-    expect_equal(q_str, kql("database('local_df').['df']\n| where ['dates'] == todatetime('2019-01-01')"))
+    expect_equal(q_str, kql("cluster('local_df').database('local_df').['df']\n| where ['dates'] == todatetime('2019-01-01')"))
     
 })
 
@@ -438,7 +438,7 @@ test_that("as.POSIXct() produces a Kusto datetime",
 
     q_str <- show_query(q)
 
-    expect_equal(q_str, kql("database('local_df').['df']\n| where ['dates'] == todatetime(todatetime('2019-01-01T23:59:59'))"))
+    expect_equal(q_str, kql("cluster('local_df').database('local_df').['df']\n| where ['dates'] == todatetime(todatetime('2019-01-01T23:59:59'))"))
     
 })
 
@@ -457,7 +457,7 @@ test_that("as.POSIXlt() produces a Kusto datetime",
 
     q_str <- show_query(q)
 
-    expect_equal(q_str, kql("database('local_df').['df']\n| where ['dates'] == todatetime('2019-01-01')"))
+    expect_equal(q_str, kql("cluster('local_df').database('local_df').['df']\n| where ['dates'] == todatetime('2019-01-01')"))
     
 })
 
@@ -466,18 +466,18 @@ test_that("join hinting translates correctly",
     q <- left %>%
         dplyr::inner_join(right, by = c("Species"), .strategy="broadcast")
     q_str <- show_query(q)
-    expect_equal(q_str, kql("database('local_df').['iris']\n| join kind = inner hint.strategy = broadcast (database('local_df').['iris2']) on ['Species']"))
+    expect_equal(q_str, kql("cluster('local_df').database('local_df').['iris']\n| join kind = inner hint.strategy = broadcast (cluster('local_df').database('local_df').['iris2']) on ['Species']"))
 
     q <- left %>%
         dplyr::inner_join(right2, by = c("Species", "SepalWidth"), .strategy="broadcast")
     q_str <- show_query(q)
-    expect_equal(q_str, kql("database('local_df').['iris']\n| join kind = inner hint.strategy = broadcast (database('local_df').['iris2']) on ['Species'], ['SepalWidth']"))
+    expect_equal(q_str, kql("cluster('local_df').database('local_df').['iris']\n| join kind = inner hint.strategy = broadcast (cluster('local_df').database('local_df').['iris2']) on ['Species'], ['SepalWidth']"))
 
     q <- left %>%
         dplyr::inner_join(right2, by = c("Species", "SepalWidth"), .strategy="shuffle",
                           .shufflekeys=c("Species", "SepalWidth"))
     q_str <- show_query(q)
-    expect_equal(q_str, kql("database('local_df').['iris']\n| join kind = inner hint.strategy = shuffle hint.shufflekey = ['Species'] hint.shufflekey = ['SepalWidth'] (database('local_df').['iris2']) on ['Species'], ['SepalWidth']"))
+    expect_equal(q_str, kql("cluster('local_df').database('local_df').['iris']\n| join kind = inner hint.strategy = shuffle hint.shufflekey = ['Species'] hint.shufflekey = ['SepalWidth'] (cluster('local_df').database('local_df').['iris2']) on ['Species'], ['SepalWidth']"))
 
     # only numeric input to .num_partitions allowed
     q <- left %>%
@@ -491,7 +491,7 @@ test_that("join hinting translates correctly",
                           .shufflekeys=c("Species", "SepalWidth"),
                           .num_partitions=2)
     q_str <- show_query(q)
-    expect_equal(q_str, kql("database('local_df').['iris']\n| join kind = inner hint.strategy = shuffle hint.shufflekey = ['Species'] hint.shufflekey = ['SepalWidth'] hint.num_partitions = 2 (database('local_df').['iris2']) on ['Species'], ['SepalWidth']"))
+    expect_equal(q_str, kql("cluster('local_df').database('local_df').['iris']\n| join kind = inner hint.strategy = shuffle hint.shufflekey = ['Species'] hint.shufflekey = ['SepalWidth'] hint.num_partitions = 2 (cluster('local_df').database('local_df').['iris2']) on ['Species'], ['SepalWidth']"))
 })
 
 test_that("summarize hinting translates correctly",
@@ -500,13 +500,13 @@ test_that("summarize hinting translates correctly",
         dplyr::group_by(Species) %>%
         dplyr::summarize(MaxSepalLength = max(SepalLength, na.rm = TRUE), .strategy="shuffle")
     q_str <- q %>% show_query()
-    expect_equal(q_str, kql("database('local_df').['iris']\n| summarize hint.strategy = shuffle ['MaxSepalLength'] = max(['SepalLength']) by ['Species']"))
+    expect_equal(q_str, kql("cluster('local_df').database('local_df').['iris']\n| summarize hint.strategy = shuffle ['MaxSepalLength'] = max(['SepalLength']) by ['Species']"))
 
     q <- tbl_iris %>%
         dplyr::group_by(Species) %>%
         dplyr::summarize(MaxSepalLength = max(SepalLength, na.rm = TRUE), .shufflekeys=c("SepalLength", "SepalWidth"))
     q_str <- q %>% show_query()
-    expect_equal(q_str, kql("database('local_df').['iris']\n| summarize hint.shufflekey = ['SepalLength'] hint.shufflekey = ['SepalWidth'] ['MaxSepalLength'] = max(['SepalLength']) by ['Species']"))
+    expect_equal(q_str, kql("cluster('local_df').database('local_df').['iris']\n| summarize hint.shufflekey = ['SepalLength'] hint.shufflekey = ['SepalWidth'] ['MaxSepalLength'] = max(['SepalLength']) by ['Species']"))
 
     # only numeric input to .num_partitions allowed
     q <- tbl_iris %>%
@@ -520,5 +520,5 @@ test_that("summarize hinting translates correctly",
         dplyr::summarize(MaxSepalLength = max(SepalLength, na.rm = TRUE),
             .shufflekeys=c("SepalLength", "SepalWidth"), .num_partitions=2)
     q_str <- q %>% show_query()
-    expect_equal(q_str, kql("database('local_df').['iris']\n| summarize hint.shufflekey = ['SepalLength'] hint.shufflekey = ['SepalWidth'] hint.num_partitions = 2 ['MaxSepalLength'] = max(['SepalLength']) by ['Species']"))
+    expect_equal(q_str, kql("cluster('local_df').database('local_df').['iris']\n| summarize hint.shufflekey = ['SepalLength'] hint.shufflekey = ['SepalWidth'] hint.num_partitions = 2 ['MaxSepalLength'] = max(['SepalLength']) by ['Species']"))
 })


### PR DESCRIPTION
This implements support for cross-cluster joins:

```r
# tables from different databases in different clusters
ir <- tbl_kusto(db1, "iris")
spec <- tbl_kusto(db2, "species")

qry <- left_join(ir, spec)
qry
#<Kusto query>
#<KQL> cluster('https://server1.location1.kusto.windows.net').database('db1').['iris']
#| join kind = leftouter (cluster('https://server2.location2.kusto.windows.net').database('db2').['species']) on ['species']

# hinting for remote
qry2 <- left_join(ir, spec, .remote = "left")
qry2
#<Kusto query>
#<KQL> cluster('https://server1.location1.kusto.windows.net').database('db1').['iris']
#| join kind = leftouter hint.remote = left (cluster('https://server2.location2.kusto.windows.net').database('db2').['species']) on ['species']
```
The simplest way to make this work was to render the full table spec (`cluster('srvname').database('dbname').['tblname']`) in each query. It does uglify the rendered query though.

