### PR TITLE
bugfix: regression in summarize clause generation

### DIFF
--- a/R/kql-build.R
+++ b/R/kql-build.R
@@ -133,7 +133,7 @@ kql_build.op_summarise <- function(op, ...)
     stmts <- mapply(translate_kql, assigned_exprs)
     pieces <- lapply(seq_along(assigned_exprs),
                      function(i) sprintf("%s = %s", escape(ident(names(assigned_exprs)[i])), stmts[i]))
-    groups <- build_kql(escape(ident(op$groups), collapse = ", "))
+    groups <- build_kql(escape(ident(op_grps(op)), collapse = ", "))
     by <- ifelse(nchar(groups) > 0, paste0(" by ", groups), "")
 
     .strategy <- if(!is.null(op$args$.strategy))
@@ -152,10 +152,11 @@ kql_build.op_summarise <- function(op, ...)
     else if(!is.null(op$args$.num_partitions))
         stop(".num_partitions must be a number", .call=FALSE)
     else NULL
-    
+
     # paste(c(*), collapse="") will not insert extra spaces when NULLs present
     smry_str <- paste(c("summarize", .strategy, .shufflekeys, .num_partitions, " "), collapse="")
-    kql(ident_q(paste0(smry_str, pieces, by)))
+    smry_clauses <- paste(pieces, collapse=", ")
+    kql(ident_q(paste0(smry_str, smry_clauses, by)))
 }
 
 #' @export

--- a/tests/testthat/test_translate.r
+++ b/tests/testthat/test_translate.r
@@ -191,6 +191,32 @@ test_that("group_by() followed by summarize() generates summarize clause",
     expect_equal(q_str, kql("cluster('local_df').database('local_df').['iris']\n| summarize ['MaxSepalLength'] = max(['SepalLength']) by ['Species']"))
 })
 
+test_that("group_by() followed by summarize() with multiple summarizations generates one summarize clause",
+{
+
+    q <- tbl_iris %>%
+        dplyr::group_by(Species) %>%
+        dplyr::summarize(MaxSepalLength = max(SepalLength, na.rm = TRUE),
+                         MaxSepalWidth = max(SepalWidth, na.rm = TRUE))
+
+    q_str <- q %>% show_query()
+
+    expect_equal(q_str, kql("cluster('local_df').database('local_df').['iris']\n| summarize ['MaxSepalLength'] = max(['SepalLength']), ['MaxSepalWidth'] = max(['SepalWidth']) by ['Species']"))
+})
+
+test_that("group_by() followed by summarize() with multiple summarizations generates one summarize clause in presence of hints",
+{
+
+    q <- tbl_iris %>%
+        dplyr::group_by(Species) %>%
+        dplyr::summarize(MaxSepalLength = max(SepalLength, na.rm = TRUE),
+                         MaxSepalWidth = max(SepalWidth, na.rm = TRUE), .strategy="shuffle")
+
+    q_str <- q %>% show_query()
+
+    expect_equal(q_str, kql("cluster('local_df').database('local_df').['iris']\n| summarize hint.strategy = shuffle ['MaxSepalLength'] = max(['SepalLength']), ['MaxSepalWidth'] = max(['SepalWidth']) by ['Species']"))
+})
+
 test_that("group_by() followed by ungroup() followed by summarize() generates summarize clause",
 {
 


### PR DESCRIPTION
At some point we had a regression that started causing `summarize()` with multiple arguments to start generating separate summarize clauses in KQL instead of creating one summarize clause with multiple arguments. This PR fixes that bug and adds regression tests.